### PR TITLE
Hex lattice for Python API

### DIFF
--- a/examples/python/lattice/hexagonal/build-xml.py
+++ b/examples/python/lattice/hexagonal/build-xml.py
@@ -99,12 +99,29 @@ root.add_cell(cell1)
 
 # Instantiate a Lattice
 lattice = openmc.HexLattice(lattice_id=5)
-lattice.set_num_rings(2)
-lattice.set_center([0., 0.])
-lattice.set_pitch([1.])
+lattice.set_num_rings(3)
+#lattice.set_center([0., 0.])
+#lattice.set_pitch([1.])
+#lattice.set_universes([
+#     [univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2],
+#     [univ2, univ2, univ2, univ2, univ2, univ2],
+#     [univ1]])
+lattice.set_center([0., 0., 0.])
+lattice.set_pitch([1., 1.])
+lattice.set_num_axial(2)
 lattice.set_universes([
-     [univ2, univ2, univ2, univ2, univ2, univ2],
-     [univ1]])
+     [
+      [univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2],
+      [univ2, univ2, univ2, univ2, univ2, univ2],
+      [univ1]
+     ],
+     [
+      [univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2],
+      [univ2, univ2, univ2, univ2, univ2, univ2],
+      [univ1]
+     ]
+     ])
+lattice.set_outer(univ1)
 
 # Fill Cell with the Lattice
 cell1.set_fill(lattice)

--- a/examples/python/lattice/hexagonal/build-xml.py
+++ b/examples/python/lattice/hexagonal/build-xml.py
@@ -99,28 +99,11 @@ root.add_cell(cell1)
 
 # Instantiate a Lattice
 lattice = openmc.HexLattice(lattice_id=5)
-lattice.set_num_rings(3)
-#lattice.set_center([0., 0.])
-#lattice.set_pitch([1.])
-#lattice.set_universes([
-#     [univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2],
-#     [univ2, univ2, univ2, univ2, univ2, univ2],
-#     [univ1]])
 lattice.set_center([0., 0., 0.])
 lattice.set_pitch([1., 1.])
-lattice.set_num_axial(2)
 lattice.set_universes([
-     [
-      [univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2],
-      [univ2, univ2, univ2, univ2, univ2, univ2],
-      [univ1]
-     ],
-     [
-      [univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2, univ2],
-      [univ2, univ2, univ2, univ2, univ2, univ2],
-      [univ1]
-     ]
-     ])
+     [ [univ2]*12, [univ2]*6, [univ1] ],
+     [ [univ2]*12, [univ2]*6, [univ1] ]])
 lattice.set_outer(univ1)
 
 # Fill Cell with the Lattice

--- a/examples/python/lattice/hexagonal/build-xml.py
+++ b/examples/python/lattice/hexagonal/build-xml.py
@@ -19,6 +19,7 @@ particles = 10000
 h1 = openmc.Nuclide('H-1')
 o16 = openmc.Nuclide('O-16')
 u235 = openmc.Nuclide('U-235')
+fe56 = openmc.Nuclide('Fe-56')
 
 # Instantiate some Materials and register the appropriate Nuclides
 fuel = openmc.Material(material_id=1, name='fuel')
@@ -31,10 +32,14 @@ moderator.add_nuclide(h1, 2.)
 moderator.add_nuclide(o16, 1.)
 moderator.add_s_alpha_beta('HH2O', '71t')
 
+iron = openmc.Material(material_id=3, name='iron')
+iron.set_density('g/cc', 7.9)
+iron.add_nuclide(fe56, 1.)
+
 # Instantiate a MaterialsFile, register all Materials, and export to XML
 materials_file = openmc.MaterialsFile()
 materials_file.set_default_xs('71c')
-materials_file.add_materials([moderator, fuel])
+materials_file.add_materials([moderator, fuel, iron])
 materials_file.export_to_xml()
 
 
@@ -43,13 +48,11 @@ materials_file.export_to_xml()
 ###############################################################################
 
 # Instantiate Surfaces
-left = openmc.XPlane(surface_id=1, x0=-2, name='left')
-right = openmc.XPlane(surface_id=2, x0=2, name='right')
-bottom = openmc.YPlane(surface_id=3, y0=-2, name='bottom')
-top = openmc.YPlane(surface_id=4, y0=2, name='top')
-fuel1 = openmc.ZCylinder(surface_id=5, x0=0, y0=0, R=0.4)
-fuel2 = openmc.ZCylinder(surface_id=6, x0=0, y0=0, R=0.3)
-fuel3 = openmc.ZCylinder(surface_id=7, x0=0, y0=0, R=0.2)
+left = openmc.XPlane(surface_id=1, x0=-3, name='left')
+right = openmc.XPlane(surface_id=2, x0=3, name='right')
+bottom = openmc.YPlane(surface_id=3, y0=-4, name='bottom')
+top = openmc.YPlane(surface_id=4, y0=4, name='top')
+fuel_surf = openmc.ZCylinder(surface_id=5, x0=0, y0=0, R=0.4)
 
 left.set_boundary_type('vacuum')
 right.set_boundary_type('vacuum')
@@ -60,51 +63,48 @@ bottom.set_boundary_type('vacuum')
 cell1 = openmc.Cell(cell_id=1, name='Cell 1')
 cell2 = openmc.Cell(cell_id=101, name='cell 2')
 cell3 = openmc.Cell(cell_id=102, name='cell 3')
-cell4 = openmc.Cell(cell_id=201, name='cell 4')
-cell5 = openmc.Cell(cell_id=202, name='cell 5')
-cell6 = openmc.Cell(cell_id=301, name='cell 6')
-cell7 = openmc.Cell(cell_id=302, name='cell 7')
+cell4 = openmc.Cell(cell_id=500, name='cell 4')
+cell5 = openmc.Cell(cell_id=600, name='cell 5')
+cell6 = openmc.Cell(cell_id=601, name='cell 6')
 
 # Register Surfaces with Cells
 cell1.add_surface(left, halfspace=+1)
 cell1.add_surface(right, halfspace=-1)
 cell1.add_surface(bottom, halfspace=+1)
 cell1.add_surface(top, halfspace=-1)
-cell2.add_surface(fuel1, halfspace=-1)
-cell3.add_surface(fuel1, halfspace=+1)
-cell4.add_surface(fuel2, halfspace=-1)
-cell5.add_surface(fuel2, halfspace=+1)
-cell6.add_surface(fuel3, halfspace=-1)
-cell7.add_surface(fuel3, halfspace=+1)
+cell2.add_surface(fuel_surf, halfspace=-1)
+cell3.add_surface(fuel_surf, halfspace=+1)
+cell5.add_surface(fuel_surf, halfspace=-1)
+cell6.add_surface(fuel_surf, halfspace=+1)
 
 # Register Materials with Cells
 cell2.set_fill(fuel)
 cell3.set_fill(moderator)
-cell4.set_fill(fuel)
-cell5.set_fill(moderator)
-cell6.set_fill(fuel)
-cell7.set_fill(moderator)
+cell4.set_fill(moderator)
+cell5.set_fill(iron)
+cell6.set_fill(moderator)
 
 # Instantiate Universe
 univ1 = openmc.Universe(universe_id=1)
-univ2 = openmc.Universe(universe_id=2)
-univ3 = openmc.Universe(universe_id=3)
+univ2 = openmc.Universe(universe_id=3)
+univ3 = openmc.Universe(universe_id=4)
 root = openmc.Universe(universe_id=0, name='root universe')
 
 # Register Cells with Universe
 univ1.add_cells([cell2, cell3])
-univ2.add_cells([cell4, cell5])
-univ3.add_cells([cell6, cell7])
+univ2.add_cells([cell4])
+univ3.add_cells([cell5, cell6])
 root.add_cell(cell1)
 
 # Instantiate a Lattice
 lattice = openmc.HexLattice(lattice_id=5)
 lattice.set_center([0., 0., 0.])
-lattice.set_pitch([1., 1.])
+lattice.set_pitch([1., 2.])
 lattice.set_universes([
-     [ [univ2]*12, [univ2]*6, [univ1] ],
-     [ [univ2]*12, [univ2]*6, [univ1] ]])
-lattice.set_outer(univ1)
+     [ [univ2] + [univ3]*11, [univ2] + [univ3]*5, [univ3] ],
+     [ [univ2] + [univ1]*11, [univ2] + [univ1]*5, [univ1] ],
+     [ [univ2] + [univ3]*11, [univ2] + [univ3]*5, [univ3] ]])
+lattice.set_outer(univ2)
 
 # Fill Cell with the Lattice
 cell1.set_fill(lattice)
@@ -136,40 +136,23 @@ settings_file.export_to_xml()
 #                   Exporting to OpenMC plots.xml File
 ###############################################################################
 
-plot = openmc.Plot(plot_id=1)
-plot.set_origin([0, 0, 0])
-plot.set_width([4, 4])
-plot.set_pixels([400, 400])
-plot.set_color('mat')
+plot_xy = openmc.Plot(plot_id=1)
+plot_xy.set_filename('plot_xy')
+plot_xy.set_origin([0, 0, 0])
+plot_xy.set_width([6, 6])
+plot_xy.set_pixels([400, 400])
+plot_xy.set_color('mat')
+
+plot_yz = openmc.Plot(plot_id=2)
+plot_yz.set_filename('plot_yz')
+plot_yz.set_basis('yz')
+plot_yz.set_origin([0, 0, 0])
+plot_yz.set_width([8, 8])
+plot_yz.set_pixels([400, 400])
+plot_yz.set_color('mat')
 
 # Instantiate a PlotsFile, add Plot, and export to XML
 plot_file = openmc.PlotsFile()
-plot_file.add_plot(plot)
+plot_file.add_plot(plot_xy)
+plot_file.add_plot(plot_yz)
 plot_file.export_to_xml()
-
-
-###############################################################################
-#                   Exporting to OpenMC tallies.xml File
-###############################################################################
-
-# Instantiate a tally mesh
-mesh = openmc.Mesh(mesh_id=1)
-mesh.set_type('rectangular')
-mesh.set_dimension([4, 4])
-mesh.set_lower_left([-2, -2])
-mesh.set_width([1, 1])
-
-# Instantiate tally Filter
-mesh_filter = openmc.Filter()
-mesh_filter.set_mesh(mesh)
-
-# Instantiate the Tally
-tally = openmc.Tally(tally_id=1)
-tally.add_filter(mesh_filter)
-tally.add_score('total')
-
-# Instantiate a TalliesFile, register Tally/Mesh, and export to XML
-tallies_file = openmc.TalliesFile()
-tallies_file.add_mesh(mesh)
-tallies_file.add_tally(tally)
-tallies_file.export_to_xml()

--- a/examples/python/lattice/hexagonal/build-xml.py
+++ b/examples/python/lattice/hexagonal/build-xml.py
@@ -1,0 +1,175 @@
+import openmc
+
+
+###############################################################################
+#                      Simulation Input File Parameters
+###############################################################################
+
+# OpenMC simulation parameters
+batches = 20
+inactive = 10
+particles = 10000
+
+
+###############################################################################
+#                 Exporting to OpenMC materials.xml File
+###############################################################################
+
+# Instantiate some Nuclides
+h1 = openmc.Nuclide('H-1')
+o16 = openmc.Nuclide('O-16')
+u235 = openmc.Nuclide('U-235')
+
+# Instantiate some Materials and register the appropriate Nuclides
+fuel = openmc.Material(material_id=1, name='fuel')
+fuel.set_density('g/cc', 4.5)
+fuel.add_nuclide(u235, 1.)
+
+moderator = openmc.Material(material_id=2, name='moderator')
+moderator.set_density('g/cc', 1.0)
+moderator.add_nuclide(h1, 2.)
+moderator.add_nuclide(o16, 1.)
+moderator.add_s_alpha_beta('HH2O', '71t')
+
+# Instantiate a MaterialsFile, register all Materials, and export to XML
+materials_file = openmc.MaterialsFile()
+materials_file.set_default_xs('71c')
+materials_file.add_materials([moderator, fuel])
+materials_file.export_to_xml()
+
+
+###############################################################################
+#                 Exporting to OpenMC geometry.xml File
+###############################################################################
+
+# Instantiate Surfaces
+left = openmc.XPlane(surface_id=1, x0=-2, name='left')
+right = openmc.XPlane(surface_id=2, x0=2, name='right')
+bottom = openmc.YPlane(surface_id=3, y0=-2, name='bottom')
+top = openmc.YPlane(surface_id=4, y0=2, name='top')
+fuel1 = openmc.ZCylinder(surface_id=5, x0=0, y0=0, R=0.4)
+fuel2 = openmc.ZCylinder(surface_id=6, x0=0, y0=0, R=0.3)
+fuel3 = openmc.ZCylinder(surface_id=7, x0=0, y0=0, R=0.2)
+
+left.set_boundary_type('vacuum')
+right.set_boundary_type('vacuum')
+top.set_boundary_type('vacuum')
+bottom.set_boundary_type('vacuum')
+
+# Instantiate Cells
+cell1 = openmc.Cell(cell_id=1, name='Cell 1')
+cell2 = openmc.Cell(cell_id=101, name='cell 2')
+cell3 = openmc.Cell(cell_id=102, name='cell 3')
+cell4 = openmc.Cell(cell_id=201, name='cell 4')
+cell5 = openmc.Cell(cell_id=202, name='cell 5')
+cell6 = openmc.Cell(cell_id=301, name='cell 6')
+cell7 = openmc.Cell(cell_id=302, name='cell 7')
+
+# Register Surfaces with Cells
+cell1.add_surface(left, halfspace=+1)
+cell1.add_surface(right, halfspace=-1)
+cell1.add_surface(bottom, halfspace=+1)
+cell1.add_surface(top, halfspace=-1)
+cell2.add_surface(fuel1, halfspace=-1)
+cell3.add_surface(fuel1, halfspace=+1)
+cell4.add_surface(fuel2, halfspace=-1)
+cell5.add_surface(fuel2, halfspace=+1)
+cell6.add_surface(fuel3, halfspace=-1)
+cell7.add_surface(fuel3, halfspace=+1)
+
+# Register Materials with Cells
+cell2.set_fill(fuel)
+cell3.set_fill(moderator)
+cell4.set_fill(fuel)
+cell5.set_fill(moderator)
+cell6.set_fill(fuel)
+cell7.set_fill(moderator)
+
+# Instantiate Universe
+univ1 = openmc.Universe(universe_id=1)
+univ2 = openmc.Universe(universe_id=2)
+univ3 = openmc.Universe(universe_id=3)
+root = openmc.Universe(universe_id=0, name='root universe')
+
+# Register Cells with Universe
+univ1.add_cells([cell2, cell3])
+univ2.add_cells([cell4, cell5])
+univ3.add_cells([cell6, cell7])
+root.add_cell(cell1)
+
+# Instantiate a Lattice
+lattice = openmc.HexLattice(lattice_id=5)
+lattice.set_num_rings(2)
+lattice.set_center([0., 0.])
+lattice.set_pitch([1.])
+lattice.set_universes([
+     [univ2, univ2, univ2, univ2, univ2, univ2],
+     [univ1]])
+
+# Fill Cell with the Lattice
+cell1.set_fill(lattice)
+
+# Instantiate a Geometry and register the root Universe
+geometry = openmc.Geometry()
+geometry.set_root_universe(root)
+
+# Instantiate a GeometryFile, register Geometry, and export to XML
+geometry_file = openmc.GeometryFile()
+geometry_file.set_geometry(geometry)
+geometry_file.export_to_xml()
+
+
+###############################################################################
+#                   Exporting to OpenMC settings.xml File
+###############################################################################
+
+# Instantiate a SettingsFile, set all runtime parameters, and export to XML
+settings_file = openmc.SettingsFile()
+settings_file.set_batches(batches)
+settings_file.set_inactive(inactive)
+settings_file.set_particles(particles)
+settings_file.set_source_space('box', [-1, -1, -1, 1, 1, 1])
+settings_file.export_to_xml()
+
+
+###############################################################################
+#                   Exporting to OpenMC plots.xml File
+###############################################################################
+
+plot = openmc.Plot(plot_id=1)
+plot.set_origin([0, 0, 0])
+plot.set_width([4, 4])
+plot.set_pixels([400, 400])
+plot.set_color('mat')
+
+# Instantiate a PlotsFile, add Plot, and export to XML
+plot_file = openmc.PlotsFile()
+plot_file.add_plot(plot)
+plot_file.export_to_xml()
+
+
+###############################################################################
+#                   Exporting to OpenMC tallies.xml File
+###############################################################################
+
+# Instantiate a tally mesh
+mesh = openmc.Mesh(mesh_id=1)
+mesh.set_type('rectangular')
+mesh.set_dimension([4, 4])
+mesh.set_lower_left([-2, -2])
+mesh.set_width([1, 1])
+
+# Instantiate tally Filter
+mesh_filter = openmc.Filter()
+mesh_filter.set_mesh(mesh)
+
+# Instantiate the Tally
+tally = openmc.Tally(tally_id=1)
+tally.add_filter(mesh_filter)
+tally.add_score('total')
+
+# Instantiate a TalliesFile, register Tally/Mesh, and export to XML
+tallies_file = openmc.TalliesFile()
+tallies_file.add_mesh(mesh)
+tallies_file.add_tally(tally)
+tallies_file.export_to_xml()

--- a/src/utils/openmc/universe.py
+++ b/src/utils/openmc/universe.py
@@ -1108,35 +1108,43 @@ class HexLattice(Lattice):
             self.set_num_rings(self._universes.shape[0])
 
         # Make sure there are the correct number of elements in each ring.
-        z = 0
-        while True:
-            if n_dims == 3:
-                axial_slice = self._universes[z]
-            else:
-                axial_slice = self._universes
+        if n_dims == 3:
+            for axial_slice in self._universes:
+              # Check the center ring.
+              if len(axial_slice[-1]) != 1:
+                  msg = 'HexLattice ID={0:d} has the wrong number of ' \
+                        'elements in the innermost ring.  Only 1 element is ' \
+                        'allowed in the innermost ring.'.format(self._id)
+                  raise ValueError(msg)
 
-            # Check the center ring.
-            if len(axial_slice[-1]) != 1:
-                msg = 'HexLattice ID={0:d} has the wrong number of elements ' \
-                      'in the innermost ring.  Only 1 element is allowed in ' \
-                      'the innermost ring.'.format(self._id)
-                raise ValueError(msg)
+              # Check the outer rings.
+              for r in range(self._num_rings-1):
+                  if len(axial_slice[r]) != 6*(self._num_rings - 1 - r):
+                      msg = 'HexLattice ID={0:d} has the wrong number of ' \
+                            'elements in ring number {1:d} (counting from the '\
+                            'outermost ring).  This ring should have {2:d} ' \
+                            'elements.'.format(self._id, r,
+                            6*(self._num_rings - 1 - r))
+                      raise ValueError(msg)
 
-            # Check the outer rings.
-            for r in range(self._num_rings-1):
-                if len(axial_slice[r]) != 6*(self._num_rings - 1 - r):
-                    msg = 'HexLattice ID={0:d} has the wrong number of ' \
-                          'elements in ring number {1:d} (counting from the ' \
-                          'outermost ring).  This ring should have {2:d} ' \
-                          'elements.'.format(self._id, r,
-                          6*(self._num_rings - 1 - r))
-                    raise ValueError(msg)
+        else:
+          axial_slice = self._universes
+          # Check the center ring.
+          if len(axial_slice[-1]) != 1:
+              msg = 'HexLattice ID={0:d} has the wrong number of ' \
+                    'elements in the innermost ring.  Only 1 element is ' \
+                    'allowed in the innermost ring.'.format(self._id)
+              raise ValueError(msg)
 
-            if n_dims == 3:
-                z += 1
-                if z == self._num_axial: break
-            else:
-                break
+          # Check the outer rings.
+          for r in range(self._num_rings-1):
+              if len(axial_slice[r]) != 6*(self._num_rings - 1 - r):
+                  msg = 'HexLattice ID={0:d} has the wrong number of ' \
+                        'elements in ring number {1:d} (counting from the '\
+                        'outermost ring).  This ring should have {2:d} ' \
+                        'elements.'.format(self._id, r,
+                        6*(self._num_rings - 1 - r))
+                  raise ValueError(msg)
 
 
     def __repr__(self):
@@ -1157,22 +1165,14 @@ class HexLattice(Lattice):
             string += '{0: <16}{1}{2}\n'.format('\tOuter', '=\t',
                                                 self._outer)
 
-        string += '{0: <16}'.format('\tUniverses')
+        string += '{0: <16}\n'.format('\tUniverses')
 
-        z = 0
-        while True:
-            if self._num_axial is not None:
-                axial_slice = self._universes[z]
-            else:
-                axial_slice = self._universes
+        if self._num_axial is not None:
+            slices = [self._repr_axial_slice(x) for x in self._universes]
+            string += '\n'.join(slices)
 
-            string += '\n' + self._repr_axial_slice(axial_slice)
-
-            if self._num_axial is not None:
-                z += 1
-                if z == self._num_axial: break
-            else:
-                break
+        else:
+            string += self._repr_axial_slice(self._universes)
 
         return string
 
@@ -1306,7 +1306,7 @@ class HexLattice(Lattice):
                 universe = universes[r_prime][theta]
                 rows[y].append(id_form.format(universe._id))
 
-                # Translate the indecies.
+                # Translate the indices.
                 y -= 1
                 theta += 1
 
@@ -1316,7 +1316,7 @@ class HexLattice(Lattice):
                 universe = universes[r_prime][theta]
                 rows[y].append(id_form.format(universe._id))
 
-                # Translate the indecies.
+                # Translate the indices.
                 y -= 2
                 theta += 1
 
@@ -1326,7 +1326,7 @@ class HexLattice(Lattice):
                 universe = universes[r_prime][theta]
                 rows[y].append(id_form.format(universe._id))
 
-                # Translate the indecies.
+                # Translate the indices.
                 y -= 1
                 theta += 1
 
@@ -1339,7 +1339,7 @@ class HexLattice(Lattice):
                 universe = universes[r_prime][theta]
                 rows[y].insert(0, id_form.format(universe._id))
 
-                # Translate the indecies.
+                # Translate the indices.
                 y += 1
                 theta += 1
 
@@ -1349,7 +1349,7 @@ class HexLattice(Lattice):
                 universe = universes[r_prime][theta]
                 rows[y].insert(0, id_form.format(universe._id))
 
-                # Translate the indecies.
+                # Translate the indices.
                 y += 2
                 theta += 1
 
@@ -1359,7 +1359,7 @@ class HexLattice(Lattice):
                 universe = universes[r_prime][theta]
                 rows[y].insert(0, id_form.format(universe._id))
 
-                # Translate the indecies.
+                # Translate the indices.
                 y += 1
                 theta += 1
 

--- a/src/utils/openmc/universe.py
+++ b/src/utils/openmc/universe.py
@@ -1157,18 +1157,22 @@ class HexLattice(Lattice):
             string += '{0: <16}{1}{2}\n'.format('\tOuter', '=\t',
                                                 self._outer)
 
-        string += '{0: <16}\n'.format('\tUniverses')
+        string += '{0: <16}'.format('\tUniverses')
 
-        # FIXME: This loop must be revised for hexagonal lattice ordering
-        # Lattice nested Universe IDs - column major for Fortran
-        for i, universe in enumerate(np.ravel(self._universes)):
-            string += '{0} '.format(universe._id)
+        z = 0
+        while True:
+            if self._num_axial is not None:
+                axial_slice = self._universes[z]
+            else:
+                axial_slice = self._universes
 
-            # Add a newline character every time we reach end of row of cells
-            if (i+1) % self._dimension[-1] == 0:
-                string += '\n'
+            string += '\n' + self._repr_axial_slice(axial_slice)
 
-        string = string.rstrip('\n')
+            if self._num_axial is not None:
+                z += 1
+                if z == self._num_axial: break
+            else:
+                break
 
         return string
 
@@ -1363,8 +1367,8 @@ class HexLattice(Lattice):
             assert y == middle + 2*r
             assert theta == len(universes[r_prime])
 
-        # Join each row into a single string.
-        rows = [pad.join(x) for x in rows]
+        # Flip the rows and join each row into a single string.
+        rows = [pad.join(x) for x in rows[::-1]]
 
         # Pad the beginning of the rows so they line up properly.
         for y in range(self._num_rings - 1):

--- a/src/utils/openmc/universe.py
+++ b/src/utils/openmc/universe.py
@@ -1275,8 +1275,6 @@ class HexLattice(Lattice):
         outer ring.
         """
 
-        assert len(universes) == self._num_rings
-
         # Find the largest universe ID and count the number of digits so we can
         # properly pad the output string later.
         largest_id = max([max([univ._id for univ in ring])
@@ -1330,9 +1328,6 @@ class HexLattice(Lattice):
                 y -= 1
                 theta += 1
 
-            # Make sure we reached the bottom.
-            assert y == middle - 2*r
-
             # Climb up the bottom-left.
             for i in range(r):
                 # Add the universe.
@@ -1362,10 +1357,6 @@ class HexLattice(Lattice):
                 # Translate the indices.
                 y += 1
                 theta += 1
-
-            # Make sure we reached the top and used all the universes.
-            assert y == middle + 2*r
-            assert theta == len(universes[r_prime])
 
         # Flip the rows and join each row into a single string.
         rows = [pad.join(x) for x in rows[::-1]]

--- a/src/utils/openmc/universe.py
+++ b/src/utils/openmc/universe.py
@@ -1273,14 +1273,21 @@ class HexLattice(Lattice):
 
         assert len(universes) == self._num_rings
 
+        # Find the largest universe ID and count the number of digits so we can
+        # properly pad the output string later.
+        largest_id = max([max([univ._id for univ in ring])
+                          for ring in universes])
+        n_digits = len(str(largest_id))
+        pad = ' '*n_digits
+        id_form = '{: ^' + str(n_digits) + 'd}'
+
         # Initialize the list for each row.
         rows = [ [] for i in range(1 + 4 * (self._num_rings-1)) ]
-        middle = self._num_rings - 1
         middle = 2 * (self._num_rings - 1)
 
         # Start with the degenerate first ring.
         universe = universes[-1][0]
-        rows[middle] = [str(universe._id)]
+        rows[middle] = [id_form.format(universe._id)]
 
         # Add universes one ring at a time.
         for r in range(1, self._num_rings):
@@ -1293,7 +1300,7 @@ class HexLattice(Lattice):
             for i in range(r):
                 # Add the universe.
                 universe = universes[r_prime][theta]
-                rows[y].append(str(universe._id))
+                rows[y].append(id_form.format(universe._id))
 
                 # Translate the indecies.
                 y -= 1
@@ -1303,7 +1310,7 @@ class HexLattice(Lattice):
             for i in range(r):
                 # Add the universe.
                 universe = universes[r_prime][theta]
-                rows[y].append(str(universe._id))
+                rows[y].append(id_form.format(universe._id))
 
                 # Translate the indecies.
                 y -= 2
@@ -1313,7 +1320,7 @@ class HexLattice(Lattice):
             for i in range(r):
                 # Add the universe.
                 universe = universes[r_prime][theta]
-                rows[y].append(str(universe._id))
+                rows[y].append(id_form.format(universe._id))
 
                 # Translate the indecies.
                 y -= 1
@@ -1326,7 +1333,7 @@ class HexLattice(Lattice):
             for i in range(r):
                 # Add the universe.
                 universe = universes[r_prime][theta]
-                rows[y].insert(0, str(universe._id))
+                rows[y].insert(0, id_form.format(universe._id))
 
                 # Translate the indecies.
                 y += 1
@@ -1336,7 +1343,7 @@ class HexLattice(Lattice):
             for i in range(r):
                 # Add the universe.
                 universe = universes[r_prime][theta]
-                rows[y].insert(0, str(universe._id))
+                rows[y].insert(0, id_form.format(universe._id))
 
                 # Translate the indecies.
                 y += 2
@@ -1346,7 +1353,7 @@ class HexLattice(Lattice):
             for i in range(r):
                 # Add the universe.
                 universe = universes[r_prime][theta]
-                rows[y].insert(0, str(universe._id))
+                rows[y].insert(0, id_form.format(universe._id))
 
                 # Translate the indecies.
                 y += 1
@@ -1356,8 +1363,18 @@ class HexLattice(Lattice):
             assert y == middle + 2*r
             assert theta == len(universes[r_prime])
 
-        # Collapse the list of lists of IDs into one string.
-        rows = [' '.join(x) for x in rows]
-        universe_ids = '\n'.join(rows)
+        # Join each row into a single string.
+        rows = [pad.join(x) for x in rows]
 
+        # Pad the beginning of the rows so they line up properly.
+        for y in range(self._num_rings - 1):
+            rows[y] = (self._num_rings - 1 - y)*pad + rows[y]
+            rows[-1 - y] = (self._num_rings - 1 - y)*pad + rows[-1 - y]
+
+        for y in range(self._num_rings % 2, self._num_rings, 2):
+            rows[middle + y] = pad + rows[middle + y]
+            if y != 0: rows[middle - y] = pad + rows[middle - y]
+
+        # Join the rows together and return the string.
+        universe_ids = '\n'.join(rows)
         return universe_ids


### PR DESCRIPTION
This PR will add hex lattice capability to the python API.  It's not complete on it's own; here are the unresolved issues:

- [x] Make the example a little more clear; double check that it will run properly
- [x] Fix `__repr__`
- [x] Add length checking for `set_universes`
- [x] Add whitespace padding to `repr_axial_slice` to make it more readable

Before I address those issues I want to double-check with you that the way I am indexing the universe list is okay.  It looks like you meant for the list to be indexed is `universes[ring #][angular #][axial #]`, but I think it will be much easier if we use the scheme `universes[axial #][ring #][angular #]`.  That second scheme is the one I used here because it made it easy to use a function like `_repr_axial_slice`, but I'm sure I can change to the first scheme if you strongly prefer it.