### PR TITLE
Fix documentation problems

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.pngmath',
+              'sphinx.ext.autosummary',
               'sphinxcontrib.tikz',
               'sphinx_numfig',
               'notebook_sphinxext']

--- a/docs/source/pythonapi/mgxs.rst
+++ b/docs/source/pythonapi/mgxs.rst
@@ -4,5 +4,38 @@
 Multi-Group Cross Sections
 ==========================
 
-.. automodule:: openmc.mgxs.mgxs
+.. autoclass:: openmc.mgxs.mgxs.MGXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.AbsorptionXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.CaptureXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.Chi
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.FissionXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.NuFissionXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.NuScatterXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.NuScatterMatrixXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.ScatterXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.ScatterMatrixXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.TotalXS
+    :members:
+
+.. autoclass:: openmc.mgxs.mgxs.TransportXS
     :members:

--- a/docs/source/pythonapi/mgxs.rst
+++ b/docs/source/pythonapi/mgxs.rst
@@ -4,38 +4,63 @@
 Multi-Group Cross Sections
 ==========================
 
-.. autoclass:: openmc.mgxs.mgxs.MGXS
+.. currentmodule:: openmc.mgxs.mgxs
+
+----------------------------
+Summary of Available Classes
+----------------------------
+
+.. autosummary::
+
+   MGXS
+   AbsorptionXS
+   CaptureXS
+   Chi
+   FissionXS
+   NuFissionXS
+   NuScatterXS
+   NuScatterMatrixXS
+   ScatterXS
+   ScatterMatrixXS
+   TotalXS
+   TransportXS
+
+-------------------
+Class Documentation
+-------------------
+
+.. autoclass:: MGXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.AbsorptionXS
+.. autoclass:: AbsorptionXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.CaptureXS
+.. autoclass:: CaptureXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.Chi
+.. autoclass:: Chi
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.FissionXS
+.. autoclass:: FissionXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.NuFissionXS
+.. autoclass:: NuFissionXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.NuScatterXS
+.. autoclass:: NuScatterXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.NuScatterMatrixXS
+.. autoclass:: NuScatterMatrixXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.ScatterXS
+.. autoclass:: ScatterXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.ScatterMatrixXS
+.. autoclass:: ScatterMatrixXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.TotalXS
+.. autoclass:: TotalXS
     :members:
 
-.. autoclass:: openmc.mgxs.mgxs.TransportXS
+.. autoclass:: TransportXS
     :members:

--- a/docs/source/pythonapi/mgxs.rst
+++ b/docs/source/pythonapi/mgxs.rst
@@ -5,4 +5,4 @@ Multi-Group Cross Sections
 ==========================
 
 .. automodule:: openmc.mgxs.mgxs
-    :members: MGXS
+    :members:

--- a/docs/source/pythonapi/opencg_compatible.rst
+++ b/docs/source/pythonapi/opencg_compatible.rst
@@ -1,8 +1,8 @@
-.. _pythonapi_openmc_mgxs:
+.. _pythonapi_opencg_compatible:
 
-==========================
-Multi-Group Cross Sections
-==========================
+====================
+OpenCG Compatibility
+====================
 
-.. automodule:: openmc.mgxs.mgxs
+.. automodule:: openmc.opencg_compatible
     :members:

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -511,8 +511,9 @@ class Filter(object):
             surface, material or universe ID corresponding to each filter bin.
 
             For 'distribcell' filters, the DataFrame either includes:
-            1) a single column with the cell instance IDs (without summary info)
-            2) separate columns for the cell IDs, universe IDs, and lattice IDs
+
+            1. a single column with the cell instance IDs (without summary info)
+            2. separate columns for the cell IDs, universe IDs, and lattice IDs
                and x,y,z cell indices corresponding to each (with summary info).
 
             For 'energy' and 'energyout' filters, the DataFrame include a single

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -330,9 +330,7 @@ class Library(object):
         ----------
         domain : Material or Cell or Universe or Integral
             The material, cell, or universe object of interest (or its ID)
-        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission',
-                     'nu-fission', 'scatter', 'nu-scatter', 'scatter matrix',
-                     'nu-scatter matrix', 'chi'}
+        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission', 'nu-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'chi'}
             The type of multi-group cross section object to return
 
         Returns

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -247,9 +247,7 @@ class MGXS(object):
 
         Parameters
         ----------
-        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission',
-                     'nu-fission', 'scatter', 'nu-scatter', 'scatter matrix',
-                     'nu-scatter matrix', 'chi'}
+        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission', 'nu-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'chi'}
             The type of multi-group cross section object to return
         domain : Material or Cell or Universe
             The domain for spatial homogenization
@@ -327,8 +325,8 @@ class MGXS(object):
         """Get the atomic number density in units of atoms/b-cm for a nuclide
         in the cross section's spatial domain.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         nuclide : str
             A nuclide name string (e.g., 'U-235')
 
@@ -362,8 +360,8 @@ class MGXS(object):
         """Get an array of atomic number densities in units of atom/b-cm for all
         nuclides in the cross section's spatial domain.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         nuclides : Iterable of str or 'all' or 'sum'
             A list of nuclide name strings (e.g., ['U-235', 'U-238']). The
             special string 'all' will return the atom densities for all nuclides

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -1269,7 +1269,7 @@ class Tally(object):
         correspond directly to the two filters with two and four bins.
 
         Parameters
-        ---------
+        ----------
         value : str
             A string for the type of value to return  - 'mean' (default),
             'std_dev', 'rel_err', 'sum', or 'sum_sq' are accepted


### PR DESCRIPTION
Most are pretty obvious. The list of reaction types unfortunately has to be a single line to render correctly in the generated documentation. I'm not sure if there was a reason you only marked the MGXS class under `:members:`; I've removed it as the subclasses should appear in documentation as well.