### PR TITLE
Get GROUP_STRUCTURES to show up in documentation

### DIFF
--- a/docs/source/_templates/mymodulevar.rst
+++ b/docs/source/_templates/mymodulevar.rst
@@ -1,7 +1,0 @@
-{{ fullname }}
-{{ underline }}
-
-.. currentmodule:: {{ module }}
-
-.. automodule:: {{ objname }}
-    :members:

--- a/docs/source/pythonapi/mgxs.rst
+++ b/docs/source/pythonapi/mgxs.rst
@@ -5,13 +5,21 @@
 Energy Groups
 -------------
 
+Module Variables
+++++++++++++++++
+
+.. autodata:: openmc.mgxs.GROUP_STRUCTURES
+    :annotation:
+
+Classes
++++++++
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
-    :template: myclass.rst mymodulevar.rst
+    :template: myclass.rst
 
     openmc.mgxs.EnergyGroups
-    openmc.mgxs.GROUP_STRUCTURES
 
 Multi-group Cross Sections
 --------------------------

--- a/openmc/mgxs/__init__.py
+++ b/openmc/mgxs/__init__.py
@@ -5,11 +5,10 @@ from openmc.mgxs.mgxs import *
 from openmc.mgxs.mdgxs import *
 
 GROUP_STRUCTURES = {}
-"""Commonly used energy group structures, including "CASMO-X" (where X
-is 2, 4, 8, 16, 25, 40 or 70) from the [CASMO]_ lattice physics code.
+"""Dictionary of commonly used energy group structures, including "CASMO-X" (where X
+is 2, 4, 8, 16, 25, 40 or 70) from the CASMO_ lattice physics code.
 
-    .. [CASMO] J. Rhodes, K. Smith, and D. Lee, "CASMO-5 Development and
-        Applications", *Proc. ANS Topical Meeting on Reactor Physics* (2006).
+.. _CASMO: https://www.studsvik.com/SharepointFiles/CASMO-5%20Development%20and%20Applications.pdf
 
 """
 


### PR DESCRIPTION
Looks like `.. autodata::` is the way to go.